### PR TITLE
Add artob/edky

### DIFF
--- a/README.md
+++ b/README.md
@@ -1526,3 +1526,4 @@ A curated list of awesome Rust frameworks, libraries and software.
 * [dalek-cryptography/curve25519-dalek](https://github.com/dalek-cryptography/curve25519-dalek) - A pure-Rust implementation of group operations on Ristretto and Curve25519
 * [sayanarijit/qrcode.show](https://github.com/sayanarijit/qrcode.show) - [WORKING PROTOTYPE] Generate QR code easily for free - QR Code Generation as a Service
 * [withoutboats/fehler](https://github.com/withoutboats/fehler) - Rust doesn't have exceptions
+* [artob/edky](https://github.com/artob/edky) - A command-line utility to convert Ed25519 public keys between various encoding formats (Base58, Base64, IPFS, iroh, libp2p, OpenSSH, etc).


### PR DESCRIPTION
**[Edky] converts Ed25519 public keys between various encoding formats, such as Base16, Base58, Base64, etc.**

```shellsession
$ cargo binstall -y edky

$ edky convert -f hex -t base64url d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a
11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo

$ edky convert -f hex -t openssh d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINdamAGCsQq31Uv+08lkBzoO4XLz2qYjJa8CGmj3B1Ea
```

<img width="100%" alt="Showcase of edky convert" src="https://github.com/artob/edky/raw/master/rust/etc/asciinema/convert.gif"/>

[Edky]: https://github.com/artob/edky
